### PR TITLE
Gradle build scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: java
+
+sudo: required
+
+dist: trusty
+
+install: true
+
+cache:
+    directories:
+        - $HOME/.m2
+        - $HOME/.gradle
+
+before_script:
+    - ./gradlew --version
+
+script:
+    - TERM=dumb ./gradlew build --scan
+
+jdk:
+    - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,13 @@
 plugins {
+	id 'com.gradle.build-scan' version '1.16'
 	id 'java-gradle-plugin'
 	id 'maven-publish'
-	id 'com.gradle.plugin-publish' version '0.10.0'
+	id 'com.gradle.plugin-publish' version '0.10.1'
+}
+
+buildScan {
+	termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+	termsOfServiceAgree = 'yes'
 }
 
 group 'io.github.rwinch.antora'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
-version=0.0.2-SNAPSHOT
+version=0.0.2-SNAPSHOTorg.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.