### PR TITLE
Make plugin configurable and allow multiple Antora tasks

### DIFF
--- a/src/main/java/io/github/rwinch/antora/Antora.java
+++ b/src/main/java/io/github/rwinch/antora/Antora.java
@@ -1,0 +1,25 @@
+package io.github.rwinch.antora;
+
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+import javax.inject.Inject;
+
+public class Antora {
+	public static final String ID = "antora";
+
+	private Property<String> antoraVersion;
+
+	@Inject
+	public Antora( ObjectFactory objects ) {
+		antoraVersion = objects.property( String.class );
+	}
+
+	public Property<String> getAntoraVersion() {
+		return antoraVersion;
+	}
+
+	public void antoraVersion( String antoraVersion ) {
+		this.antoraVersion.set( antoraVersion );
+	}
+}

--- a/src/main/java/io/github/rwinch/antora/Antora.java
+++ b/src/main/java/io/github/rwinch/antora/Antora.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.rwinch.antora;
 
 import org.gradle.api.model.ObjectFactory;

--- a/src/main/java/io/github/rwinch/antora/AntoraPlugin.java
+++ b/src/main/java/io/github/rwinch/antora/AntoraPlugin.java
@@ -22,7 +22,6 @@ import com.moowork.gradle.node.npm.NpmTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.tasks.Exec;
 import org.gradle.internal.os.OperatingSystem;
 
 import java.io.File;
@@ -32,35 +31,85 @@ import java.util.Arrays;
  * @author Rob Winch
  */
 public class AntoraPlugin implements Plugin<Project> {
+
+	public static final String DOWNLOAD_ANTORA_TASK_NAME = "downloadAntora";
+
+	private static final String DOWNLOAD_ANTORA_CLI_TASK_NAME = "downloadAntoraCli";
+
+	private static final String DOWNLOAD_ANTORA_GENERATOR_TASK_NAME = "downloadAntoraSiteGenerator";
+
+	private static final String DEFAULT_ANTORA_TASK_NAME = "antora";
+
+	private static final String ANTORA_CLI_PACKAGE_NAME = "@antora/cli";
+
+	private static final String ANTORA_GENERATOR_PACKAGE_NAME = "@antora/site-generator-default";
+
+	private static final String INSTALL = "install";
+
+	private Project project;
+
 	@Override
 	public void apply(Project project) {
+		this.project = project;
+		project.getExtensions().create(Antora.ID, Antora.class);
 		project.getPlugins().apply(NodePlugin.class);
 
-		NodeExtension node = project.getExtensions().getByType(NodeExtension.class);
+		NodeExtension node = NodeExtension.get(project);
 		node.setDownload(true);
 		node.setVersion("8.11.4");
-		node.setNodeModulesDir(project.file(new File(project.getBuildDir(), "/modules")));
+		final File nodeModulesDir = project.file(new File(project.getBuildDir(), "/modules"));
+		node.setNodeModulesDir(nodeModulesDir);
 
+		registerSetupTasks();
+
+		registerDefaultTasks();
+
+		registerAntoraVersionOverrideHandler();
+	}
+
+	private void registerSetupTasks() {
 		NpmTask downloadAntoraCli = project.getTasks()
-				.create("downloadAntoraCli", NpmTask.class);
-		downloadAntoraCli.setArgs(Arrays.asList("install", "@antora/cli"));
+				.create(DOWNLOAD_ANTORA_CLI_TASK_NAME, NpmTask.class);
+		downloadAntoraCli.setArgs(Arrays.asList(INSTALL, ANTORA_CLI_PACKAGE_NAME));
 
 		NpmTask downloadAntoraSiteGenerator = project.getTasks()
-				.create("downloadAntoraSiteGenerator", NpmTask.class);
-		downloadAntoraSiteGenerator.setArgs(Arrays.asList("install", "@antora/site-generator-default"));
+				.create(DOWNLOAD_ANTORA_GENERATOR_TASK_NAME, NpmTask.class);
+		downloadAntoraSiteGenerator.setArgs(Arrays.asList(INSTALL, ANTORA_GENERATOR_PACKAGE_NAME));
 
-		Task downloadAntora = project.getTasks().create("downloadAntora");
-		downloadAntora.dependsOn(downloadAntoraCli, downloadAntoraSiteGenerator);
+		Task downloadAntora = project.getTasks()
+				.create(DOWNLOAD_ANTORA_TASK_NAME)
+				.dependsOn(downloadAntoraCli, downloadAntoraSiteGenerator);
+	}
 
-		Exec antora = project.getTasks().create("antora", Exec.class);
-		antora.setGroup("Docs");
-		antora.setDescription("Installs and runs antora site.yml");
-		antora.dependsOn(downloadAntora);
-		antora.setCommandLine(antoraCommand(), "site.yml");
+	private void registerDefaultTasks() {
+		project.getTasks().register(DEFAULT_ANTORA_TASK_NAME, AntoraTask.class);
+	}
+
+
+	private void registerAntoraVersionOverrideHandler() {
+		project.afterEvaluate(evaluatedProject -> {
+			if (config().getAntoraVersion().isPresent()) {
+				final String antoraVersion = config().getAntoraVersion().get();
+				project.getTasks()
+						.named(DOWNLOAD_ANTORA_CLI_TASK_NAME, NpmTask.class)
+						.configure(downloadAntoraCli -> {
+							downloadAntoraCli.setArgs(Arrays.asList(INSTALL, ANTORA_CLI_PACKAGE_NAME + "@" + antoraVersion));
+						});
+				project.getTasks()
+						.named(DOWNLOAD_ANTORA_GENERATOR_TASK_NAME, NpmTask.class)
+						.configure(downloadAntoraGenerator -> {
+							downloadAntoraGenerator.setArgs(Arrays.asList(INSTALL, ANTORA_GENERATOR_PACKAGE_NAME + "@" + antoraVersion));
+						});
+			}
+		});
 	}
 
 	private String antoraCommand() {
 		String command = "build/modules/node_modules/.bin/antora";
 		return OperatingSystem.current().isWindows() ? command + ".cmd" : command;
+	}
+
+	private Antora config() {
+		return (Antora) project.getExtensions().getByName(Antora.ID);
 	}
 }

--- a/src/main/java/io/github/rwinch/antora/AntoraTask.java
+++ b/src/main/java/io/github/rwinch/antora/AntoraTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.rwinch.antora;
 
 import org.gradle.api.DefaultTask;

--- a/src/main/java/io/github/rwinch/antora/AntoraTask.java
+++ b/src/main/java/io/github/rwinch/antora/AntoraTask.java
@@ -1,0 +1,43 @@
+package io.github.rwinch.antora;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.os.OperatingSystem;
+
+import java.util.Collections;
+
+public class AntoraTask extends DefaultTask {
+
+	private static final String DEFAULT_PLAYBOOK_FILENAME = "site.yml";
+
+	@Input
+	private Property<String> playbookFilename = getProject().getObjects().property(String.class).value(DEFAULT_PLAYBOOK_FILENAME);
+
+	public AntoraTask() {
+		super();
+		setGroup("Docs");
+		setDescription("Installs and runs antora");
+		setDependsOn(Collections.singleton(getProject().getTasks().named(AntoraPlugin.DOWNLOAD_ANTORA_TASK_NAME)));
+	}
+
+	public Property<String> getPlaybookFilename() {
+		return playbookFilename;
+	}
+
+	public void playbookFilename(final String playbookFilename) {
+		this.playbookFilename.set(playbookFilename);
+	}
+
+	@TaskAction
+	public void runAntora() {
+		getLogger().info("Running antora using playbook " + playbookFilename.get());
+		getProject().exec(execSpec -> execSpec.setCommandLine(antoraCommand(), playbookFilename.get()));
+	}
+
+	private String antoraCommand() {
+		String command = "build/modules/node_modules/.bin/antora";
+		return OperatingSystem.current().isWindows() ? command + ".cmd" : command;
+	}
+}


### PR DESCRIPTION
This PR allows the plugin to be used in a more flexible way and adds a configuration, helping with easier extension later on (e.g. it would easily be possible to steer the installation of add-ons like PlantUML via the new configuration).
The Antora task now is a class on its own, allowing to have multiple of them.
If you feel this is useful let me know, I then can also extend the README to polish this.